### PR TITLE
fix: bump the Node.js version requirement from v18 to v22.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To enable realtime updates, [Fastly Fanout](https://docs.fastly.com/products/fan
 
 The project comprises two main parts:
 
-* A web application. The backend for this web application is written in JavaScript, for [Node.js](https://nodejs.dev/) 18.x or newer.
+* A web application. The backend for this web application is written in JavaScript, for [Node.js](https://nodejs.dev/) 22.9.0 or newer.
    * It uses the [Express](https://expressjs.com/) web framework and uses [SQLite](https://www.sqlite.org/) to maintain a small database.
    * The frontend for this web application is a [React](https://react.dev/) application that is bundled using [Webpack](https://webpack.js.org/). The bundle is served by the backend as a static file.
    * The `package.json` file is at the root of this repo.


### PR DESCRIPTION
I've got `node: bad option: --env-file-if-exists=.env` error when building this project with Node v20. Turned out the `--env-file-if-exists` option [was introduced Node at v22.9.0](https://github.com/nodejs/nodejs.org/blob/main/apps/site/pages/en/blog/release/v22.9.0.md?plain=1#L176), hence bumping the Node version requirement to 22.9.0 or newer.